### PR TITLE
Clearer PrintPretty method

### DIFF
--- a/JMC.Parser/JMC/Types/JMCSyntaxNode.cs
+++ b/JMC.Parser/JMC/Types/JMCSyntaxNode.cs
@@ -26,15 +26,22 @@
             Console.Write(indent);
             if (last)
             {
-                Console.Write("\\-");
-                indent += "  ";
+                Console.Write("└── ");
+                indent += "    ";
             }
             else
             {
-                Console.Write("|-");
-                indent += "| ";
+                Console.Write("├── ");
+                indent += "│   ";
             }
-            Console.WriteLine($"{NodeType} {Value} {Range}");
+            var color = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.Write(NodeType + " ");
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.Write(Value + " ");
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine(Range);
+            Console.ForegroundColor = color;
 
             if (Next != null)
                 for (int i = 0; i < Next.Count(); i++)


### PR DESCRIPTION
This PR makes the PrintPretty method print out a cleaner syntax tree with colors for better readability. 

![image](https://github.com/WingedSeal/JMC-Syntax-Highlighting/assets/71092443/53baed4e-d63c-4a34-856b-f542824b472e)